### PR TITLE
Focus the editing area after executing mention command from the UI.

### DIFF
--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -205,13 +205,15 @@ export default class MentionUI extends Plugin {
 			const start = end.getShiftedBy( -matchedTextLength );
 			const range = model.createRange( start, end );
 
+			this._hidePanel();
+
 			editor.execute( 'mention', {
 				mention: item,
 				marker,
 				range
 			} );
 
-			this._hidePanel();
+			editor.editing.view.focus();
 		} );
 
 		return mentionsView;

--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -914,6 +914,23 @@ describe( 'MentionUI', () => {
 					expect( panelView.isVisible ).to.be.false;
 				} );
 		} );
+
+		it( 'should focus view after command execution', () => {
+			const focusSpy = testUtils.sinon.spy( editor.editing.view, 'focus' );
+
+			setData( model, '<paragraph>foo []</paragraph>' );
+
+			model.change( writer => {
+				writer.insertText( '@', doc.selection.getFirstPosition() );
+			} );
+
+			return waitForDebounce()
+				.then( () => {
+					listView.items.get( 0 ).children.get( 0 ).fire( 'execute' );
+
+					sinon.assert.calledOnce( focusSpy );
+				} );
+		} );
 	} );
 
 	function createClassicTestEditor( mentionConfig ) {


### PR DESCRIPTION
Fix: The editing area is now focused after executing mention command from the UI. Closes #14.