### PR TITLE
Remove wrong usage of highest priority from the docs and manual tests.

### DIFF
--- a/docs/_snippets/features/mention-customization.js
+++ b/docs/_snippets/features/mention-customization.js
@@ -7,11 +7,6 @@
 
 import { CS_CONFIG } from '@ckeditor/ckeditor5-cloud-services/tests/_utils/cloud-services-config';
 
-import priorities from '@ckeditor/ckeditor5-utils/src/priorities';
-
-// The link plugin using highest priority in conversion pipeline.
-const HIGHER_THEN_HIGHEST = priorities.highest + 50;
-
 ClassicEditor
 	.create( document.querySelector( '#snippet-mention-customization' ), {
 		cloudServices: CS_CONFIG,
@@ -70,7 +65,7 @@ function CustomMention( editor ) {
 				return mentionValue;
 			}
 		},
-		converterPriority: HIGHER_THEN_HIGHEST
+		converterPriority: 'high'
 	} );
 
 	function isFullMention( viewElement ) {
@@ -107,7 +102,7 @@ function CustomMention( editor ) {
 				'href': modelAttributeValue.link
 			} );
 		},
-		converterPriority: HIGHER_THEN_HIGHEST
+		converterPriority: 'high'
 	} );
 }
 

--- a/docs/features/mention.md
+++ b/docs/features/mention.md
@@ -157,14 +157,9 @@ To a link:
 <a class="mention" data-mention="Ted Mosby" data-user-id="5" href="https://www.imdb.com/title/tt0460649/characters/nm1102140">@Ted Mosby</a>
 ```
 
-The below converters must have priority higher then link attribute converter. The mention item in the model must be stored as a plain object with `name` attribute.
+The below converters must have priority 'high' priority as the link attribute converter has 'normal' priority. The mention item in the model must be stored as a plain object with `name` attribute.
 
 ```js
-import priorities from '@ckeditor/ckeditor5-utils/src/priorities';
-
-// The link plugin using highest priority in conversion pipeline.
-const HIGHER_THEN_HIGHEST = priorities.highest + 50;
-
 ClassicEditor
 	.create( document.querySelector( '#editor' ), {
 		plugins: [ Mention, CustomMention, ... ],    // Add custom mention plugin function.
@@ -207,7 +202,7 @@ function CustomMention( editor ) {
 				return mentionValue;
 			}
 		},
-		converterPriority: HIGHER_THEN_HIGHEST
+		converterPriority: 'high'
 	} );
 
 	function isFullMention( viewElement ) {
@@ -244,7 +239,7 @@ function CustomMention( editor ) {
 				'href': modelAttributeValue.link
 			} );
 		},
-		converterPriority: HIGHER_THEN_HIGHEST
+		converterPriority: 'high'
 	} );
 }
 ```

--- a/tests/manual/mention-custom-view.js
+++ b/tests/manual/mention-custom-view.js
@@ -22,12 +22,9 @@ import Link from '@ckeditor/ckeditor5-link/src/link';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 import Underline from '@ckeditor/ckeditor5-basic-styles/src/underline';
 import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
-import priorities from '@ckeditor/ckeditor5-utils/src/priorities';
 
 import MentionUI from '../../src/mentionui';
 import MentionEditing from '../../src/mentionediting';
-
-const HIGHER_THEN_HIGHEST = priorities.highest + 50;
 
 class CustomMentionAttributeView extends Plugin {
 	init() {
@@ -53,7 +50,7 @@ class CustomMentionAttributeView extends Plugin {
 					return mentionValue;
 				}
 			},
-			converterPriority: HIGHER_THEN_HIGHEST
+			converterPriority: 'high'
 		} );
 
 		editor.conversion.for( 'downcast' ).attributeToElement( {
@@ -69,7 +66,7 @@ class CustomMentionAttributeView extends Plugin {
 					'href': modelAttributeValue.link
 				} );
 			},
-			converterPriority: HIGHER_THEN_HIGHEST
+			converterPriority: 'high'
 		} );
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Docs: Remove wrong usage of highest priority from the docs and manual tests. Closes #16.

---

### Additional information

* works ok - dunno why I thought link had 'highest' priority :/
