### PR TITLE
T/40:  Add mention feed configuration validation for marker.

### DIFF
--- a/src/mentioncommand.js
+++ b/src/mentioncommand.js
@@ -95,9 +95,9 @@ export default class MentionCommand extends Command {
 			 *
 			 * See {@link module:mention/mention~MentionConfig}.
 			 *
-			 * @error markercommand-incorrect-marker
+			 * @error mentioncommand-incorrect-marker
 			 */
-			throw new CKEditorError( 'markercommand-incorrect-marker: The marker must be a single character.' );
+			throw new CKEditorError( 'mentioncommand-incorrect-marker: The marker must be a single character.' );
 		}
 
 		if ( mentionID.charAt( 0 ) != options.marker ) {
@@ -124,9 +124,9 @@ export default class MentionCommand extends Command {
 			 *
 			 * See {@link module:mention/mention~MentionConfig}.
 			 *
-			 * @error markercommand-incorrect-id
+			 * @error mentioncommand-incorrect-id
 			 */
-			throw new CKEditorError( 'markercommand-incorrect-id: The item id must start with the marker character.' );
+			throw new CKEditorError( 'mentioncommand-incorrect-id: The item id must start with the marker character.' );
 		}
 
 		model.change( writer => {

--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -14,6 +14,7 @@ import BalloonPanelView from '@ckeditor/ckeditor5-ui/src/panel/balloon/balloonpa
 import clickOutsideHandler from '@ckeditor/ckeditor5-ui/src/bindings/clickoutsidehandler';
 import { keyCodes } from '@ckeditor/ckeditor5-utils/src/keyboard';
 import Rect from '@ckeditor/ckeditor5-utils/src/dom/rect';
+import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
 
 import TextWatcher from './textwatcher';
 
@@ -110,6 +111,22 @@ export default class MentionUI extends Plugin {
 			const feed = mentionDescription.feed;
 
 			const marker = mentionDescription.marker;
+
+			if ( !marker || marker.length != 1 ) {
+				/**
+				 * The marker must be a single character.
+				 *
+				 * Correct markers: `'@'`, `'#'`.
+				 *
+				 * Incorrect markers: `'$$'`, `'[@'`.
+				 *
+				 * See {@link module:mention/mention~MentionConfig}.
+				 *
+				 * @error mentionconfig-incorrect-marker
+				 */
+				throw new CKEditorError( 'mentionconfig-incorrect-marker: The marker must be provided and be a single character.' );
+			}
+
 			const minimumCharacters = mentionDescription.minimumCharacters || 0;
 			const feedCallback = typeof feed == 'function' ? feed : createFeedCallback( feed );
 			const watcher = this._setupTextWatcherForFeed( marker, minimumCharacters );

--- a/tests/manual/mention-custom-renderer.js
+++ b/tests/manual/mention-custom-renderer.js
@@ -25,6 +25,7 @@ ClassicEditor
 		mention: {
 			feeds: [
 				{
+					marker: '@',
 					feed: getFeed,
 					itemRenderer: item => {
 						const span = document.createElement( 'span' );

--- a/tests/manual/mention-custom-view.js
+++ b/tests/manual/mention-custom-view.js
@@ -70,7 +70,10 @@ ClassicEditor
 		],
 		mention: {
 			feeds: [
-				{ feed: getFeed }
+				{
+					marker: '@',
+					feed: getFeed
+				}
 			]
 		}
 	} )

--- a/tests/manual/mention.js
+++ b/tests/manual/mention.js
@@ -27,13 +27,14 @@ ClassicEditor
 		mention: {
 			feeds: [
 				{
-					feed: [ 'Barney', 'Lily', 'Marshall', 'Robin', 'Ted' ]
+					marker: '@',
+					feed: [ '@Barney', '@Lily', '@Marshall', '@Robin', '@Ted' ]
 				},
 				{
 					marker: '#',
 					feed: [
-						'a01', 'a02', 'a03', 'a04', 'a05', 'a06', 'a07', 'a08', 'a09', 'a10',
-						'a11', 'a12', 'a13', 'a14', 'a15', 'a16', 'a17', 'a18', 'a19', 'a20'
+						'#a01', '#a02', '#a03', '#a04', '#a05', '#a06', '#a07', '#a08', '#a09', '#a10',
+						'#a11', '#a12', '#a13', '#a14', '#a15', '#a16', '#a17', '#a18', '#a19', '#a20'
 					]
 				}
 			]

--- a/tests/mentioncommand.js
+++ b/tests/mentioncommand.js
@@ -145,7 +145,7 @@ describe( 'MentionCommand', () => {
 			];
 
 			for ( const options of testCases ) {
-				expect( () => command.execute( options ) ).to.throw( CKEditorError, /markercommand-incorrect-marker/ );
+				expect( () => command.execute( options ) ).to.throw( CKEditorError, /mentioncommand-incorrect-marker/ );
 			}
 		} );
 
@@ -159,7 +159,7 @@ describe( 'MentionCommand', () => {
 			];
 
 			for ( const options of testCases ) {
-				expect( () => command.execute( options ) ).to.throw( CKEditorError, /markercommand-incorrect-id/ );
+				expect( () => command.execute( options ) ).to.throw( CKEditorError, /mentioncommand-incorrect-id/ );
 			}
 		} );
 	} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Mention feature will throw error for empty marker in mention feed configuration . Closes #40.

---

### Additional information

* I've also fixed the `markercommand-` typo in error names.