### PR TITLE
Exclude Edge from mention scroll test assertions.

### DIFF
--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -338,7 +338,7 @@ describe( 'MentionUI', () => {
 					} );
 			} );
 
-			it( 'should scroll mention panel to the selected item', function() {
+			it( 'should scroll mention panel to the selected item', () => {
 				setData( model, '<paragraph>foo []</paragraph>' );
 
 				model.change( writer => {
@@ -357,8 +357,6 @@ describe( 'MentionUI', () => {
 					stopPropagation: sinon.spy()
 				};
 
-				const elementSpies = [];
-
 				const mentionElementSpy = testUtils.sinon.spy( mentionsView.element, 'scrollTop', [ 'set' ] );
 
 				return waitForDebounce()
@@ -375,8 +373,6 @@ describe( 'MentionUI', () => {
 							const listItemElement = item.children.get( 0 ).element;
 
 							listItemElement.style = `min-height:unset;height:25px;max-height:25px;${ reset };min-width:12em;`;
-
-							elementSpies.push( testUtils.sinon.spy( listItemElement, 'offsetTop', [ 'get' ] ) );
 						} );
 
 						// ...so after those changes it is safe to assume that:
@@ -385,7 +381,6 @@ describe( 'MentionUI', () => {
 						// - if scrolled to the last element scrollTop will be set to 150px. The 150px is the offset of the 7th item in the
 						//   list as last four (7, 8, 9 & 10) will be visible.
 						expect( panelView.isVisible ).to.be.true;
-
 						expectChildViewsIsOnState( [ true, false, false, false, false, false, false, false, false, false ] );
 
 						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
@@ -396,7 +391,6 @@ describe( 'MentionUI', () => {
 						fireKeyDownEvent( arrowDownEvtData );
 
 						expectChildViewsIsOnState( [ false, true, false, false, false, false, false, false, false, false ] );
-
 						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
 						if ( !env.isEdge ) {
 							expect( mentionsView.element.scrollTop ).to.equal( 0 );
@@ -406,10 +400,10 @@ describe( 'MentionUI', () => {
 						fireKeyDownEvent( arrowUpEvtData );
 
 						expectChildViewsIsOnState( [ true, false, false, false, false, false, false, false, false, false ] );
+						expect( mentionsView.element.scrollTop ).to.equal( 0 );
 
 						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
 						if ( !env.isEdge ) {
-							expect( mentionsView.element.scrollTop ).to.equal( 0 );
 							sinon.assert.callCount( mentionElementSpy.set, 0 );
 						}
 
@@ -417,10 +411,11 @@ describe( 'MentionUI', () => {
 
 						expectChildViewsIsOnState( [ false, false, false, false, false, false, false, false, false, true ] );
 
+						// We want 150, but sometimes we get e.g. 151.
+						expect( mentionsView.element.scrollTop ).to.be.within( 140, 160, 'last item highlighted' );
+
 						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
 						if ( !env.isEdge ) {
-							// We want 150, but sometimes we get e.g. 151.
-							expect( mentionsView.element.scrollTop ).to.be.within( 140, 160, 'last item highlighted' );
 							sinon.assert.callCount( mentionElementSpy.set, 1 );
 						}
 

--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -16,6 +16,7 @@ import { setData } from '@ckeditor/ckeditor5-engine/src/dev-utils/model';
 import DomEventData from '@ckeditor/ckeditor5-engine/src/view/observer/domeventdata';
 import EventInfo from '@ckeditor/ckeditor5-utils/src/eventinfo';
 import CKEditorError from '@ckeditor/ckeditor5-utils/src/ckeditorerror';
+import env from '@ckeditor/ckeditor5-utils/src/env';
 
 import MentionUI from '../src/mentionui';
 import MentionEditing from '../src/mentionediting';
@@ -337,35 +338,45 @@ describe( 'MentionUI', () => {
 					} );
 			} );
 
-			it( 'should scroll mention panel to the selected item', () => {
+			it( 'should scroll mention panel to the selected item', function() {
 				setData( model, '<paragraph>foo []</paragraph>' );
 
 				model.change( writer => {
 					writer.insertText( '@', doc.selection.getFirstPosition() );
 				} );
 
+				const arrowDownEvtData = {
+					keyCode: keyCodes.arrowdown,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				const arrowUpEvtData = {
+					keyCode: keyCodes.arrowup,
+					preventDefault: sinon.spy(),
+					stopPropagation: sinon.spy()
+				};
+
+				const elementSpies = [];
+
+				const mentionElementSpy = testUtils.sinon.spy( mentionsView.element, 'scrollTop', [ 'set' ] );
+
 				return waitForDebounce()
 					.then( () => {
-						const arrowDownEvtData = {
-							keyCode: keyCodes.arrowdown,
-							preventDefault: sinon.spy(),
-							stopPropagation: sinon.spy()
-						};
-
-						const arrowUpEvtData = {
-							keyCode: keyCodes.arrowup,
-							preventDefault: sinon.spy(),
-							stopPropagation: sinon.spy()
-						};
-
 						// The scroll test highly depends on browser styles.
 						// Some CI test environments might not load theme which will result that tests will not render on CI as locally.
 						// To make this test repeatable across different environments it enforces mentions view size to 100px...
-						mentionsView.element.style = 'height:100px;padding:0px;margin:0px';
+						const reset = 'padding:0px;margin:0px;border:0 none;line-height: 1em;';
+
+						mentionsView.element.style = `min-height:100px;height:100px;max-height:100px;${ reset };`;
 
 						// ...and each list view item size to 25px...
 						Array.from( mentionsView.items ).forEach( item => {
-							item.children.get( 0 ).element.style = 'height:25px;padding:0px;margin:0px;';
+							const listItemElement = item.children.get( 0 ).element;
+
+							listItemElement.style = `min-height:unset;height:25px;max-height:25px;${ reset };min-width:12em;`;
+
+							elementSpies.push( testUtils.sinon.spy( listItemElement, 'offsetTop', [ 'get' ] ) );
 						} );
 
 						// ...so after those changes it is safe to assume that:
@@ -376,25 +387,54 @@ describe( 'MentionUI', () => {
 						expect( panelView.isVisible ).to.be.true;
 
 						expectChildViewsIsOnState( [ true, false, false, false, false, false, false, false, false, false ] );
-						expect( mentionsView.element.scrollTop ).to.equal( 0 );
+
+						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
+						if ( !env.isEdge ) {
+							sinon.assert.callCount( mentionElementSpy.set, 0 );
+						}
 
 						fireKeyDownEvent( arrowDownEvtData );
 
 						expectChildViewsIsOnState( [ false, true, false, false, false, false, false, false, false, false ] );
-						expect( mentionsView.element.scrollTop ).to.equal( 0 );
+
+						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
+						if ( !env.isEdge ) {
+							expect( mentionsView.element.scrollTop ).to.equal( 0 );
+							sinon.assert.callCount( mentionElementSpy.set, 0 );
+						}
 
 						fireKeyDownEvent( arrowUpEvtData );
+
 						expectChildViewsIsOnState( [ true, false, false, false, false, false, false, false, false, false ] );
-						expect( mentionsView.element.scrollTop ).to.equal( 0 );
+
+						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
+						if ( !env.isEdge ) {
+							expect( mentionsView.element.scrollTop ).to.equal( 0 );
+							sinon.assert.callCount( mentionElementSpy.set, 0 );
+						}
 
 						fireKeyDownEvent( arrowUpEvtData );
+
 						expectChildViewsIsOnState( [ false, false, false, false, false, false, false, false, false, true ] );
-						expect( mentionsView.element.scrollTop ).to.be.within( 140, 160 ); // We want 150, but sometimes we get e.g. 151.
+
+						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
+						if ( !env.isEdge ) {
+							// We want 150, but sometimes we get e.g. 151.
+							expect( mentionsView.element.scrollTop ).to.be.within( 140, 160, 'last item highlighted' );
+							sinon.assert.callCount( mentionElementSpy.set, 1 );
+						}
 
 						fireKeyDownEvent( arrowDownEvtData );
 
 						expectChildViewsIsOnState( [ true, false, false, false, false, false, false, false, false, false ] );
-						expect( mentionsView.element.scrollTop ).to.equal( 0 );
+
+						// We want 0, but sometimes we get e.g. 1. (Firefox)
+						expect( mentionsView.element.scrollTop ).to.be.within( 0, 10 );
+
+						// Edge browser always tries to scroll in tests environment: See ckeditor5-utils#282.
+						if ( !env.isEdge ) {
+							sinon.assert.callCount( mentionElementSpy.set, 2 );
+						}
 					} );
 			} );
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Tests: Make mention ui scroll test more reliable on CI. Closes #58.

---

### Additional information

* OMG I hate Edge and browser differences (Firefox!)
