### PR TITLE
PR: Add single view mode to the contextual balloon.

### DIFF
--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -374,7 +374,9 @@ export default class MentionUI extends Plugin {
 			this._balloon.add( {
 				view: this._mentionsView,
 				position: this._getBalloonPanelPositionData( markerMarker, this._mentionsView.position ),
-				withArrow: false
+				withArrow: false,
+				singleViewMode: true,
+				stack: 'mention'
 			} );
 		}
 

--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -96,10 +96,15 @@ describe( 'MentionUI', () => {
 	} );
 
 	describe( 'contextual balloon', () => {
+		let balloonAddSpy;
+
 		beforeEach( () => {
 			return createClassicTestEditor( staticConfig )
 				.then( () => {
 					setData( model, '<paragraph>foo []</paragraph>' );
+					const contextualBalloon = editor.plugins.get( ContextualBalloon );
+
+					balloonAddSpy = sinon.spy( contextualBalloon, 'add' );
 
 					model.change( writer => {
 						writer.insertText( '@', doc.selection.getFirstPosition() );
@@ -109,6 +114,9 @@ describe( 'MentionUI', () => {
 		} );
 
 		it( 'should disable arrow', () => {
+			sinon.assert.calledOnce( balloonAddSpy );
+			sinon.assert.calledWithExactly( balloonAddSpy, sinon.match( data => data.singleViewMode ) );
+			sinon.assert.calledWithExactly( balloonAddSpy, sinon.match( data => data.stack == 'mention' ) );
 			expect( panelView.isVisible ).to.be.true;
 			expect( panelView.withArrow ).to.be.false;
 		} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The mention toolbar should be displayed as single view in contextual balloon. Closes #74.

---

### Additional information

This PR comes with constellation of changes on [ckeditor5#t/ckeditor5-mention/74](https://github.com/ckeditor/ckeditor5/tree/t/ckeditor5-mention/74) branch [![Build Status](https://travis-ci.org/ckeditor/ckeditor5.svg?branch=master)](https://travis-ci.org/ckeditor/ckeditor5). 

which includes:

* Changes in the ui - added single view mode option to contextualballoon.add(): https://github.com/ckeditor/ckeditor5-ui/pull/507.