### PR TITLE
Remove mention attribute from selection when selection is at start of…

### DIFF
--- a/src/mentionediting.js
+++ b/src/mentionediting.js
@@ -159,7 +159,7 @@ function selectionMentionAttributePostFixer( writer, doc ) {
 	const selection = doc.selection;
 	const focus = selection.focus;
 
-	if ( selection.isCollapsed && selection.hasAttribute( 'mention' ) && shouldRemoveMentionAttribute( focus ) ) {
+	if ( selection.isCollapsed && selection.hasAttribute( 'mention' ) && shouldNotTypeWithMentionAt( focus ) ) {
 		writer.removeSelectionAttribute( 'mention' );
 
 		return true;
@@ -172,9 +172,8 @@ function selectionMentionAttributePostFixer( writer, doc ) {
 // The mention attribute should be removed from a selection when selection focus is placed:
 // a) after a text node
 // b) the position is at parents start - the selection will set attributes from node after.
-function shouldRemoveMentionAttribute( position ) {
+function shouldNotTypeWithMentionAt( position ) {
 	const isAtStart = position.isAtStart;
-
 	const isAfterAMention = position.nodeBefore && position.nodeBefore.is( 'text' );
 
 	return isAfterAMention || isAtStart;

--- a/tests/mentionediting.js
+++ b/tests/mentionediting.js
@@ -272,6 +272,25 @@ describe( 'MentionEditing', () => {
 
 			expect( editor.getData() ).to.equal( '<p>foo <span class="mention" data-mention="@John">@John</span> bar</p>' );
 		} );
+
+		it( 'should not allow to type with mention attribute before mention', () => {
+			editor.setData( '<p><span class="mention" data-mention="@John">@John</span> bar</p>' );
+
+			const paragraph = doc.getRoot().getChild( 0 );
+
+			// Set selection before mention.
+			model.change( writer => {
+				writer.setSelection( paragraph, 0 );
+			} );
+
+			expect( Array.from( doc.selection.getAttributes() ) ).to.deep.equal( [] );
+
+			model.change( writer => {
+				writer.insertText( 'a', doc.selection.getAttributes(), writer.createPositionAt( paragraph, 0 ) );
+			} );
+
+			expect( editor.getData() ).to.equal( '<p>a<span class="mention" data-mention="@John">@John</span> bar</p>' );
+		} );
 	} );
 
 	describe( 'removing partial mention post-fixer', () => {


### PR DESCRIPTION
… parent block.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Remove mention attribute from selection when selection is at the beginning of a parent block. Closes #77.

---

### Additional information

* Quit quick fix - the selection set attribute from a node after if it is placed at the begining of a paragraph:

```html
<p>[]<$text mention={}>@foo</$text>
```
while in such scenario is not:
```html
<p>bar []<$text mention={}>@foo</$text>
```