### PR TITLE
Other: Bind the feed callback function to the plugin instance

### DIFF
--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -135,7 +135,7 @@ export default class MentionUI extends Plugin {
 			}
 
 			const minimumCharacters = mentionDescription.minimumCharacters || 0;
-			const feedCallback = typeof feed == 'function' ? feed : createFeedCallback( feed );
+			const feedCallback = typeof feed == 'function' ? feed.bind( this.editor ) : createFeedCallback( feed );
 			const watcher = this._setupTextWatcherForFeed( marker, minimumCharacters );
 			const itemRenderer = mentionDescription.itemRenderer;
 

--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -852,6 +852,37 @@ describe( 'MentionUI', () => {
 			} );
 		} );
 
+		describe( 'callback function using data from editor', () => {
+			beforeEach( () => {
+				return createClassicTestEditor( {
+					feeds: [
+						{
+							marker: '#',
+							feed() {
+								expect( this ).to.equal( editor );
+								return Promise.resolve( [ 'foo', 'bar' ] );
+							}
+						}
+					]
+				} );
+			} );
+
+			it( 'should bind the instance panel for matched marker', () => {
+				setData( model, '<paragraph>foo []</paragraph>' );
+
+				model.change( writer => {
+					writer.insertText( '#', doc.selection.getFirstPosition() );
+				} );
+
+				return waitForDebounce()
+					.then( () => {
+						expect( panelView.isVisible ).to.be.true;
+						expect( editor.model.markers.has( 'mention' ) ).to.be.true;
+						expect( mentionsView.items ).to.have.length( 2 );
+					} );
+			} );
+		} );
+
 		describe( 'asynchronous list with custom trigger', () => {
 			beforeEach( () => {
 				const issuesNumbers = [ '#100', '#101', '#102', '#103' ];


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other:  Bind the feed callback function to the plugin instance

---

### Additional information

We're currently using the mention feature for our own user autocompletion (thanks for the awsome work btw!). We need to have access to the editor configuration because we're passing resource related information into it (e.g., what type of resource it is results in different autocompletion options). Currently the `function` style of the `feed` option to return the allowed values however does not have a chance of accessing the mention instance and in turn the configuration or editor instance.

This PR suggests that the feed callback is being bound to the plugin instance, which is an appropriate way to bind context. Calling users can then define what context they want by using an arrow or plain function, or binding their outer context themselves.

An alternative, but potentially breaking change would be to pass the editor instance in the feed callback. It would only be breaking if it were the first parameter before the text however.
