### PR TITLE
Removed the confirmation of mention selection by using space

### DIFF
--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -33,8 +33,6 @@ const handledKeyCodes = [
 	keyCodes.arrowup,
 	keyCodes.arrowdown,
 	keyCodes.enter,
-	keyCodes.tab,
-	keyCodes.space,
 	keyCodes.esc
 ];
 
@@ -121,7 +119,7 @@ export default class MentionUI extends Plugin {
 					this._mentionsView.selectPrevious();
 				}
 
-				if ( data.keyCode == keyCodes.enter || data.keyCode == keyCodes.tab || data.keyCode == keyCodes.space ) {
+				if ( data.keyCode == keyCodes.enter ) {
 					this._mentionsView.executeSelected();
 				}
 

--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -33,6 +33,7 @@ const handledKeyCodes = [
 	keyCodes.arrowup,
 	keyCodes.arrowdown,
 	keyCodes.enter,
+	keyCodes.tab,
 	keyCodes.esc
 ];
 
@@ -119,7 +120,7 @@ export default class MentionUI extends Plugin {
 					this._mentionsView.selectPrevious();
 				}
 
-				if ( data.keyCode == keyCodes.enter ) {
+				if ( data.keyCode == keyCodes.enter || data.keyCode == keyCodes.tab ) {
 					this._mentionsView.executeSelected();
 				}
 

--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -1570,6 +1570,8 @@ describe( 'MentionUI', () => {
 
 			describe( 'on "execute" keys', () => {
 				testExecuteKey( 'enter', keyCodes.enter, feedItems );
+
+				testExecuteKey( 'tab', keyCodes.tab, feedItems );
 			} );
 		} );
 
@@ -1718,6 +1720,8 @@ describe( 'MentionUI', () => {
 
 				describe( 'on "execute" keys', () => {
 					testExecuteKey( 'enter', keyCodes.enter, issues );
+
+					testExecuteKey( 'tab', keyCodes.tab, issues );
 				} );
 			} );
 		} );
@@ -1839,6 +1843,8 @@ describe( 'MentionUI', () => {
 
 				describe( 'on "execute" keys', () => {
 					testExecuteKey( 'enter', keyCodes.enter, issues );
+
+					testExecuteKey( 'tab', keyCodes.tab, issues );
 				} );
 
 				describe( 'mouse', () => {

--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -1570,10 +1570,6 @@ describe( 'MentionUI', () => {
 
 			describe( 'on "execute" keys', () => {
 				testExecuteKey( 'enter', keyCodes.enter, feedItems );
-
-				testExecuteKey( 'tab', keyCodes.tab, feedItems );
-
-				testExecuteKey( 'space', keyCodes.space, feedItems );
 			} );
 		} );
 
@@ -1722,10 +1718,6 @@ describe( 'MentionUI', () => {
 
 				describe( 'on "execute" keys', () => {
 					testExecuteKey( 'enter', keyCodes.enter, issues );
-
-					testExecuteKey( 'tab', keyCodes.tab, issues );
-
-					testExecuteKey( 'space', keyCodes.space, issues );
 				} );
 			} );
 		} );
@@ -1847,10 +1839,6 @@ describe( 'MentionUI', () => {
 
 				describe( 'on "execute" keys', () => {
 					testExecuteKey( 'enter', keyCodes.enter, issues );
-
-					testExecuteKey( 'tab', keyCodes.tab, issues );
-
-					testExecuteKey( 'space', keyCodes.space, issues );
 				} );
 
 				describe( 'mouse', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: The `space` and `tab` keys are not anymore used to confirm a mention selection from the list. Closes ckeditor/ckeditor5#6394.