### PR TITLE
Mention UI should not appear when mention command is disabled

### DIFF
--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -406,8 +406,8 @@ export default class MentionUI extends Plugin {
 			this._hideUIAndRemoveMarker();
 		} );
 
-		const command = editor.commands.get( 'mention' );
-		watcher.bind( 'isEnabled' ).to( command );
+		const mentionCommand = editor.commands.get( 'mention' );
+		watcher.bind( 'isEnabled' ).to( mentionCommand );
 
 		return watcher;
 	}

--- a/src/mentionui.js
+++ b/src/mentionui.js
@@ -406,6 +406,9 @@ export default class MentionUI extends Plugin {
 			this._hideUIAndRemoveMarker();
 		} );
 
+		const command = editor.commands.get( 'mention' );
+		watcher.bind( 'isEnabled' ).to( command );
+
 		return watcher;
 	}
 

--- a/tests/manual/mention.js
+++ b/tests/manual/mention.js
@@ -16,6 +16,7 @@ import Plugin from '@ckeditor/ckeditor5-core/src/plugin';
 
 import { toWidget, viewToModelPositionOutsideModelElement } from '@ckeditor/ckeditor5-widget/src/utils';
 import ButtonView from '@ckeditor/ckeditor5-ui/src/button/buttonview';
+import Model from '@ckeditor/ckeditor5-ui/src/model';
 
 class InlineWidget extends Plugin {
 	constructor( editor ) {
@@ -106,15 +107,67 @@ class InlineWidget extends Plugin {
 	}
 }
 
+class MentionCommandSwitcher extends Plugin {
+	constructor( editor ) {
+		super( editor );
+
+		this.model = new Model( {
+			isEnabled: true,
+			isInitialized: false
+		} );
+	}
+
+	init() {
+		const editor = this.editor;
+		const command = editor.commands.get( 'mention' );
+
+		editor.ui.componentFactory.add( 'toggleMentionCommand', locale => {
+			const view = new ButtonView( locale );
+
+			view.set( {
+				label: 'Mentions',
+				tooltip: true,
+				withText: true,
+				isToggleable: true
+			} );
+
+			view.bind( 'isOn' ).to( this.model, 'isEnabled' );
+
+			this.listenTo( view, 'execute', () => {
+				this.model.isEnabled = !this.model.isEnabled;
+			} );
+
+			return view;
+		} );
+
+		this.model.on( 'change:isEnabled', ( evt, name, value ) => {
+			command.isEnabled = value;
+		} );
+
+		// block other sources of change
+		command.on( 'change:isEnabled', evt => {
+			if ( !this.model.isInitialized ) {
+				this.model.isInitialized = true;
+				this.model.isEnabled = command.isEnabled;
+			}
+
+			if ( !this.model.isEnabled ) {
+				command.isEnabled = false;
+				evt.stop();
+			}
+		}, { priority: 'lowest' } );
+	}
+}
+
 ClassicEditor
 	.create( global.document.querySelector( '#editor' ), {
-		plugins: [ ArticlePluginSet, Underline, Font, Mention, InlineWidget ],
+		plugins: [ ArticlePluginSet, Underline, Font, Mention, InlineWidget, MentionCommandSwitcher ],
 		toolbar: [
 			'heading',
 			'|', 'bulletedList', 'numberedList', 'blockQuote',
 			'|', 'bold', 'italic', 'underline', 'link',
 			'|', 'fontFamily', 'fontSize', 'fontColor', 'fontBackgroundColor',
-			'|', 'insertTable', 'placeholder',
+			'|', 'insertTable', 'placeholder', 'toggleMentionCommand',
 			'|', 'undo', 'redo'
 		],
 		image: {

--- a/tests/manual/mention.md
+++ b/tests/manual/mention.md
@@ -26,7 +26,7 @@ The feeds:
 You can interact with mention panel with keyboard:
 
 - Move arrows up/down to select an item.
-- Use <kbd>enter</kbd> or <kbd>tab</kbd> to insert a mention into the documentation. 
+- Use <kbd>enter</kbd> or <kbd>tab</kbd> to insert a mention into the documentation.
 - The <kbd>esc</kbd> should close the panel.
 
 Mention panel should be closed on:
@@ -41,3 +41,5 @@ The mention should be removed from the text when:
 - removing characters from a mention
 - breaking the mention (<kbd>enter</kbd>)
 - pasting part of a mention
+
+Mention UI should not appear when mention command is disabled (**Mentions** toggle in toolbar).

--- a/tests/mentionui.js
+++ b/tests/mentionui.js
@@ -351,6 +351,25 @@ describe( 'MentionUI', () => {
 				} );
 		} );
 
+		it( 'should not show panel when command is disabled', () => {
+			return createClassicTestEditor( staticConfig )
+				.then( () => {
+					setData( model, '<paragraph>foo []</paragraph>' );
+
+					const mentionCommand = editor.commands.get( 'mention' );
+					mentionCommand.forceDisabled( 'mentionCommandDisableTest' );
+
+					model.change( writer => {
+						writer.insertText( '@', doc.selection.getFirstPosition() );
+					} );
+				} )
+				.then( waitForDebounce )
+				.then( () => {
+					expect( panelView.isVisible ).to.be.false;
+					expect( editor.model.markers.has( 'mention' ) ).to.be.false;
+				} );
+		} );
+
 		describe( 'static list with large set of results', () => {
 			const bigList = {
 				marker: '@',


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Mention UI is no longer appearing when mention command is disabled. Closes ckeditor/ckeditor5#5958.
